### PR TITLE
Add validation for memory related items

### DIFF
--- a/WebAssembly.md
+++ b/WebAssembly.md
@@ -952,7 +952,7 @@ If bit `0x1` is set in `flags`, the following fields are appended.
 | `maximum`  | [varuint32]  | maximum length (in same units as `minimum`)            |
 
 **Validation:**
- - If maximum is specified, it must be greater than minimum.
+ - If maximum is specified, it must not be smaller than minimum.
 
 #### Linear-Memory Description
 

--- a/WebAssembly.md
+++ b/WebAssembly.md
@@ -591,6 +591,9 @@ The Table Section consists of an [array] of [table descriptions].
 
 The Memory Section consists of an [array] of [linear-memory descriptions].
 
+**Validation:**
+ - Linear-memory description items must be valid.
+
 > Implementations are encouraged to attempt to reserve enough resources for
 allocating up to the `maximum` length up front, if a `maximum` length is
 present. Otherwise, implementations are encouraged to allocate only enough for
@@ -948,11 +951,18 @@ If bit `0x1` is set in `flags`, the following fields are appended.
 | ---------- | ------------ | ------------------------------------------------------ |
 | `maximum`  | [varuint32]  | maximum length (in same units as `minimum`)            |
 
+**Validation:**
+ - If maximum is specified, it must be greater than minimum.
+
 #### Linear-Memory Description
 
 | Field Name | Type               | Description                                       |
 | ---------- | ------------------ | ------------------------------------------------- |
 | `limits`   | [resizable limits] | linear-memory flags and sizes in units of [pages] |
+
+**Validation:**
+ - Limits items must be valid (see above).
+ - Memory size must be at most 65536 pages (4GiB).
 
 #### Table Description
 


### PR DESCRIPTION
See reference: https://webassembly.github.io/spec/valid/types.html#valid-limits
The 4GiB limit isn't specified in the validation section of the spec, although there are some tests about it: https://github.com/WebAssembly/spec/blob/master/test/core/memory.wast#L134